### PR TITLE
Prepare Sanitizer Checker for fully automatic exploit generation

### DIFF
--- a/nodelib/package-lock.json
+++ b/nodelib/package-lock.json
@@ -9,23 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "chai": "^4.3.7",
-        "chalk": "^4.1.2",
-        "node-addon-api": "^5.0.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "chai": "^4.3.10",
+        "node-addon-api": "^5.1.0"
       }
     },
     "node_modules/assertion-error": {
@@ -37,60 +22,32 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
       "dependencies": {
         "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
+        "type-detect": "^4.0.8"
       },
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
@@ -104,19 +61,11 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/loupe": {
@@ -128,9 +77,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -138,17 +87,6 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/type-detect": {

--- a/nodelib/package.json
+++ b/nodelib/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chai": "^4.3.7",
-    "node-addon-api": "^5.0.0"
+    "chai": "^4.3.10",
+    "node-addon-api": "^5.1.0"
   }
 }

--- a/nodelib/src/index.cpp
+++ b/nodelib/src/index.cpp
@@ -1,24 +1,70 @@
 #include <napi.h>
 #include <string>
+#include <tuple>
 #include <iostream>
+#include <sstream>
+#include <cassert>
 #include "../../semattack/src/main_attack.hpp"
 
-Napi::String parseDepString(const Napi::CallbackInfo& info) {
+void printToJSConsole(Napi::Env env, const char* text);
+const char* resultStatusToString(const ResultStatus status);
+
+napi_value parseDepString(const Napi::CallbackInfo& info) {
+    napi_status status;
     Napi::Env env = info.Env();
 
     std::string depgraph = (std::string) info[0].ToString();
     std::string fieldName = (std::string) info[1].ToString();
-    std::string exploit = "";
-    std::string result;
-    std::cout.setstate(std::ios_base::failbit);
+    std::string exploit = (std::string) info[2].ToString();
+    std::string resultExploitString;
+    ResultStatus resultStatus;
+    std::ostringstream oss;
+
+    // Redirect stdout to our stringstream buffer
+    std::streambuf* oldCoutStreamBuf = std::cout.rdbuf();
+    std::cout.rdbuf(oss.rdbuf());
+
+    // Redirect stderr to our stringstream buffer
+    std::streambuf* oldCerrStreamBuf = std::cerr.rdbuf();
+    std::cerr.rdbuf(oss.rdbuf());
+
     try {
-        result = call_sem_attack("", depgraph, fieldName, exploit);
-    } catch (...) {
-        Napi::Error::New(env, "Example exception").ThrowAsJavaScriptException();
+        std::tuple<ResultStatus, std::string> result = call_sem_attack("", depgraph, fieldName, exploit);
+        resultStatus = std::get<0>(result);
+        resultExploitString = std::get<1>(result);
+    } catch (std::exception& e) {
+        Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+        // Don't forget to restore the original stream
+        std::cout.rdbuf(oldCoutStreamBuf);
+        std::cerr.rdbuf(oldCerrStreamBuf);
         return Napi::String::New(env, "error");
     }
     std::cout.clear();
-    return Napi::String::New(env, result);
+    // Redirect back to the original stream
+    std::cout.rdbuf(oldCoutStreamBuf);
+    std::cerr.rdbuf(oldCerrStreamBuf);
+
+    napi_value obj;
+    status = napi_create_object(env, &obj);
+    assert(status == napi_ok);
+
+    napi_value resultStatusValue;
+    status = napi_create_string_utf8(env, resultStatusToString(resultStatus), NAPI_AUTO_LENGTH, &resultStatusValue);
+    assert(status == napi_ok);
+
+    napi_value resultExploitStringValue;
+    status = napi_create_string_utf8(env, resultExploitString.c_str(), NAPI_AUTO_LENGTH, &resultExploitStringValue);
+    assert(status == napi_ok);
+
+    status = napi_set_named_property(env, obj, "resultStatus", resultStatusValue);
+    assert(status == napi_ok);
+
+    status = napi_set_named_property(env, obj, "resultExploitString", resultExploitStringValue);
+    assert(status == napi_ok);
+
+
+    printToJSConsole(env, oss.str().c_str());
+    return obj;
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -28,6 +74,41 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     );
 
     return exports;
+}
+
+void printToJSConsole(Napi::Env env, const char* text) {
+
+
+    napi_value global, console, log, result2;
+    napi_status status;
+
+    // Get the global object
+    status = napi_get_global(env, &global);
+
+    // Get the console object
+    status = napi_get_named_property(env, global, "console", &console);
+
+    // Get the console.log function
+    status = napi_get_named_property(env, console, "log", &log);
+
+    napi_value message;
+    // Create a JavaScript string from a C string
+    status = napi_create_string_utf8(env, text, NAPI_AUTO_LENGTH, &message);
+
+    napi_value argv[1] = { message };
+
+    // Call the function
+    status = napi_call_function(env, console, log, 1, argv, &result2);
+}
+
+const char* resultStatusToString(const ResultStatus status) {
+    switch(status) {
+        case VULNERABLE_SANITIZER_FOUND: return "VULNERABLE_SANITIZER_FOUND";
+        case VULNERABLE_NO_SANITIZER_FOUND: return "VULNERABLE_NO_SANITIZER_FOUND";
+        case NOT_VULNERABLE: return "NOT_VULNERABLE";
+        case ERROR: return "ERROR";
+        default: return "UNKNOWN";
+    }
 }
 
 NODE_API_MODULE(sanitizerchecker, Init);

--- a/nodelib/test/test.js
+++ b/nodelib/test/test.js
@@ -13,7 +13,7 @@ fs.readdir(inputFolder, (err, files) => {
         describe(file, function () {
             it('should call parseDepString on the content without an error', function () {
                 expect(valid_statuses).to.include(sanitizerChecker.parseDepString(content, "x")["resultStatus"]);
-            });
+            }).timeout(600000);
         });
     });
   });

--- a/nodelib/test/test.js
+++ b/nodelib/test/test.js
@@ -6,13 +6,13 @@ const sanitizerChecker = require('../build/Release/sanitizerchecker.node');
 const inputFolder = __dirname + '/../../input3';
 
 fs.readdir(inputFolder, (err, files) => {
-  const errors = ['None', 'InfiniteRegex', 'NotImplemented', 'Other', 'UnsupportedFunction', 'MalformedDepgraph', 'UrlInReplaceString', 'UrlInReplaceString', 'LargeEncodeAttrChain', 'LargeEncodeTextChain', 'RegExpParseError', 'MonaException', 'InvalidArgument', 'InfiniteLength'];
+  const valid_statuses = ['VULNERABLE_SANITIZER_FOUND', 'VULNERABLE_NO_SANITIZER_FOUND', "NOT_VULNERABLE"];
     files.forEach(file => {
       const absolutePath = path.resolve(inputFolder, file);
       const content = fs.readFileSync(absolutePath, {encoding: 'utf8'});
         describe(file, function () {
             it('should call parseDepString on the content without an error', function () {
-                expect(errors).to.include(sanitizerChecker.parseDepString(content, "x"));
+                expect(valid_statuses).to.include(sanitizerChecker.parseDepString(content, "x")["resultStatus"]);
             });
         });
     });

--- a/semattack/src/main_attack.hpp
+++ b/semattack/src/main_attack.hpp
@@ -1,2 +1,9 @@
 #include <string>
-std::string call_sem_attack(const std::string& target_name, const std::string& dep_graph, const std::string& field_name, std::string& exploit_string);
+#include <tuple>
+enum ResultStatus {
+    VULNERABLE_SANITIZER_FOUND,
+    VULNERABLE_NO_SANITIZER_FOUND,
+    NOT_VULNERABLE,
+    ERROR
+};
+std::tuple<ResultStatus, std::string> call_sem_attack(const std::string& target_name, const std::string& dep_graph, const std::string& field_name, const std::string& exploit_string);


### PR DESCRIPTION
- Adds the full sanitizer checker flow to the call_sem_attack function
- Redirects output from the Sanitizer Checker to JS console, if called by node-gyp
- Returns results as tuples instead of strings
- Adapts test to new return types